### PR TITLE
opendrive field added

### DIFF
--- a/aveas_openlabel/aveas_openlabel.py
+++ b/aveas_openlabel/aveas_openlabel.py
@@ -128,6 +128,7 @@ class AveasOpenLabel(BaseOpenLabel):
                 acquisition_method=AcquisitionMethod.IN_VEHICLE,
                 acquisition_partner="foo bar institute",
                 acquisition_date="2000-01-01T01:01:01.001Z",
+                opendrive="example.XODR",
                 projection_string="example projection string",
                 threshold_gttc=1.0,
                 threshold_pret=1.0,

--- a/aveas_openlabel/metadata.py
+++ b/aveas_openlabel/metadata.py
@@ -56,7 +56,7 @@ class AcquisitionMethod(str, Enum):
 class Metadata(BaseMetadata):
     """This JSON object contains metadata about the annotation file itself."""
 
-    aveas_schema_version: Literal["0.4.16"] = field(default="0.4.16")
+    aveas_schema_version: Literal["0.4.17"] = field(default="0.4.17")
     """The version of the aveas_openlabel library used to generate this file."""
 
     right_of_use: RightOfUse = field(default_factory=lambda: no_default(field="Metadata.right_of_use"), metadata=required)
@@ -92,7 +92,7 @@ class Metadata(BaseMetadata):
     opendrive: str = field(default_factory=lambda: no_default(field="Metadata.opendrive"), metadata=required)
     """
     The name of the OpenDRIVE file which contains specifications that fields in this OpenLABEL refer to.
-    The OpenDRIVE file has to use the projection string indicated under "projection_string".
+    The OpenDRIVE file has to use the projection string indicated under "Metadata.projection_string".
     """
 
     projection_string: str = field(default_factory=lambda: no_default(field="Metadata.projection_string"), metadata=required)

--- a/aveas_openlabel/metadata.py
+++ b/aveas_openlabel/metadata.py
@@ -91,10 +91,10 @@ class Metadata(BaseMetadata):
 
     opendrive: str = field(default_factory=lambda: no_default(field="Metadata.opendrive"), metadata=required)
     """
-    The name of the OpenDRIVE file belonging to the OpenLABEL, i.e., OpenDRIVE related specifications such as the lane or road ID refer to this OpenDRIVE file. 
+    The name of the OpenDRIVE file which contains specifications that fields in this OpenLABEL refer to.
     The OpenDRIVE file has to use the projection string indicated under "projection_string".
     """
-    
+
     projection_string: str = field(default_factory=lambda: no_default(field="Metadata.projection_string"), metadata=required)
     """
     The geographic reference system used for the coordinates in this OpenLABEL-file and in corresponding OpenDRIVE-files. 

--- a/aveas_openlabel/metadata.py
+++ b/aveas_openlabel/metadata.py
@@ -89,6 +89,12 @@ class Metadata(BaseMetadata):
     - Z: 'Z' if the time zone is UTC, '±[hh]:[mm]', '±[hh][mm]', or '±[hh]' otherwise, ex. '+0100'
     """
 
+    opendrive: str = field(default_factory=lambda: no_default(field="Metadata.opendrive"), metadata=required)
+    """
+    The name of the OpenDRIVE file belonging to the OpenLABEL, i.e., OpenDRIVE related specifications such as the lane or road ID refer to this OpenDRIVE file. 
+    The OpenDRIVE file has to use the projection string indicated under "projection_string".
+    """
+    
     projection_string: str = field(default_factory=lambda: no_default(field="Metadata.projection_string"), metadata=required)
     """
     The geographic reference system used for the coordinates in this OpenLABEL-file and in corresponding OpenDRIVE-files. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "aveas_openlabel"
 # When bumping this version, don't forget to update aveas_openlabel.metadata.Metadata.aveas_schema_version!
-version = "0.4.16"
+version = "0.4.17"
 description = "The AVEAS OpenLABEL specification"
 license = "MIT"
 authors = ["understand.ai <postmaster@understand.ai>"]

--- a/test_aveas_openlabel/minimum_openlabel_example.json
+++ b/test_aveas_openlabel/minimum_openlabel_example.json
@@ -6,6 +6,7 @@
       "acquisition_method": "in-vehicle",
       "acquisition_partner": "understand.ai",
       "acquisition_date": "2000-01-01T01:01:01.001Z",
+      "opendrive": "example.xodr",
       "projection_string": "dummy projection string",
       "threshold_gttc": 1.0,
       "threshold_pret": 1.0,

--- a/test_aveas_openlabel/test_aveas_openlabel.py
+++ b/test_aveas_openlabel/test_aveas_openlabel.py
@@ -29,6 +29,7 @@ def test_must_be_instantiable_and_serializable_with_metadata_only() -> None:
         acquisition_method=AcquisitionMethod.IN_VEHICLE,
         acquisition_partner="test",
         acquisition_date="yyyy-MM-ddTHH:mm:ss.FFFZ",
+        opendrive="example.xodr",
         projection_string="example projection string",
         threshold_gttc=1.0,
         threshold_pret=1.0,

--- a/test_aveas_openlabel/test_example.py
+++ b/test_aveas_openlabel/test_example.py
@@ -142,6 +142,7 @@ def test_example() -> None:
         acquisition_method=acquisition_method,
         acquisition_partner=acquisition_partner,
         acquisition_date=acquisition_date,
+        opendrive="example.XODR",
         projection_string="example projection string",
         threshold_gttc=1.0,
         threshold_pret=1.0,


### PR DESCRIPTION
as discussed in AP2, 21/11/24 added field "opendrive" to metadata, this makes sense as it is referred to by OpenDRIVE related fields such as the lane ID and the road coordinates